### PR TITLE
Add support for Lava Commands to the Lava Tester

### DIFF
--- a/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx.cs
+++ b/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx.cs
@@ -39,6 +39,7 @@ namespace RockWeb.Plugins.com_centralaz.Utility
     [DisplayName( "Lava Tester" )]
     [Category( "com_centralaz > Utility" )]
     [Description( "Allows you to pick a person, group, workflow instance, or registration entity and test your lava." )]
+    [LavaCommandsField( "Enabled Lava Commands", "The Lava commands that should be enabled.", false, order: 0 )]
     public partial class LavaTester : Rock.Web.UI.RockBlock
     {
         #region Fields
@@ -721,7 +722,7 @@ namespace RockWeb.Plugins.com_centralaz.Utility
         protected void ResolveLava()
         {
             string lava = ceLava.Text;
-            litOutput.Text = lava.ResolveMergeFields( mergeFields );
+            litOutput.Text = lava.ResolveMergeFields( mergeFields, GetAttributeValue( "EnabledLavaCommands" ) );
             if ( cbEnableDebug.Checked )
             {
                 litDebug.Text = mergeFields.lavaDebugInfo();


### PR DESCRIPTION
## Contributor Agreement
_By contributing your code, you agree to license your contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)._

## Context
_What is the problem you encountered that lead to you creating this pull request?_

Using Lava Commands with the tester required enabling the commands globally.

## Goal
_What will this pull request achieve and how will this fix the problem?_

Localize the Lava Commands to this one block.

## Strategy
_How have you implemented your solution?_

Added block setting to allow user to enable which Lava Commands are available when testing lava.

## Tests
_If your code is a new method or function (that doesn't need a mock database or SqlServerTypes library) and can be Xunit tested [see example](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/Rock/Lava/RockFiltersTests.cs) be sure your pull request includes the corresponding unit tests in the Rock.Tests project. In all cases *you* MUST test your code before submitting a pull request._

## Possible Implications
_What could this change potentially impact? Are there any security considerations? Where could this potentially affect backwards compatibility?_

## Screenshots
_Provide us some screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful._

## Documentation
_If your change effects the UI or needs to be documented in one of the existing [user guides](http://www.rockrms.com/Learn/Documentation), please provide the brief write-up here:_

## Migrations
Should your pull request require a migration, please exclude the migration from the Rock.Migration project, but submit it in your pull request. Please add a note to your pull request that provides a heads up that a migration file is present.
