### PR TITLE
- Added processing time message to Lava Tester.

### DIFF
--- a/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx
+++ b/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx
@@ -113,6 +113,9 @@
                     <div class="well" style="background-color: #fff">
                         <asp:Literal ID="litOutput" runat="server"><i class="text-muted">nothing to display yet, try pressing the Test button ;)</i></asp:Literal>
                     </div>
+                    <asp:Panel ID="pnlProcessingTime" runat="server" Visible="false">
+                        Lava processing took <asp:Literal ID="litProcessingTime" runat="server" /> seconds.
+                    </asp:Panel>
 
                     <h3 runat="server" id="h3DebugTitle" visible="false">Lava Reference / Debug</h3>
                     <asp:Literal ID="litDebug" runat="server"></asp:Literal>

--- a/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx.cs
+++ b/RockWeb/Plugins/com_centralaz/Utility/LavaTester.ascx.cs
@@ -748,7 +748,14 @@ namespace RockWeb.Plugins.com_centralaz.Utility
         protected void ResolveLava()
         {
             string lava = ceLava.Text;
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             litOutput.Text = lava.ResolveMergeFields( mergeFields, GetAttributeValue( "EnabledLavaCommands" ) );
+            sw.Stop();
+
+            litProcessingTime.Text = ( sw.ElapsedMilliseconds / 1000d ).ToString();
+            pnlProcessingTime.Visible = true;
+
             if ( cbEnableDebug.Checked )
             {
                 litDebug.Text = mergeFields.lavaDebugInfo();


### PR DESCRIPTION
## Proposed Changes

Adds a `Lava Processing took x seconds.` message after the output to the Lava Tester. This is helpful when you are trying to do performance testing on Lava and don't want to use a stopwatch or deal with the added overhead of ASP and postbacks.

![LavaCapture](https://user-images.githubusercontent.com/1119863/67905379-5f73c200-fb2e-11e9-8eea-c8354795eac0.PNG)
